### PR TITLE
extensions: cache extension querying

### DIFF
--- a/source/derelict/opengl3/internal.d
+++ b/source/derelict/opengl3/internal.d
@@ -54,10 +54,17 @@ package {
             // If OpenGL 3+ is loaded, use glGetStringi.
             if( glversion >= GLVersion.GL30 ) {
                 auto cstr = name.toStringz(  );
-                int count;
-                glGetIntegerv( GL_NUM_EXTENSIONS, &count );
+                static int count = -1;
+                static string[] extensions = [];
+
+                if (count < 0) {
+                    glGetIntegerv( GL_NUM_EXTENSIONS, &count );
+                    for( int i=0; i<count; ++i ) {
+                        extensions ~= to!string( glGetStringi( GL_EXTENSIONS, i ) );
+                    }
+                }
                 for( int i=0; i<count; ++i ) {
-                    if( strcmp( glGetStringi( GL_EXTENSIONS, i ), cstr ) == 0 )
+                    if( strcmp( extensions[i].toStringz(  ), cstr ) == 0 )
                         return true;
                 }
                 return false;


### PR DESCRIPTION
When debugging with GLSL-Debugger, the excess glGetStringi calls take
about 10 minutes to complete.

Seems to work here.
