### PR TITLE
fix backward compatability

### DIFF
--- a/source/derelict/opengl3/gl3.d
+++ b/source/derelict/opengl3/gl3.d
@@ -78,7 +78,7 @@ class DerelictGL3Loader : SharedLibLoader
         }
 
         GLVersion reload( GLVersion minVersion = GLVersion.None, GLVersion maxVersion = GLVersion.HighestSupported) {
-            import std.format : format;
+            import std.string : format;
 
             // Make sure a context is active, otherwise this could be meaningless.
             if( !hasValidContext() )


### PR DESCRIPTION
older dmd's had the format function in std.string and newer compilers right now provide it there too. (this fixes #40 )