### PR TITLE
Fix compile error in single-file compilation mode.

### DIFF
--- a/source/derelict/opengl/glloader.d
+++ b/source/derelict/opengl/glloader.d
@@ -32,13 +32,11 @@ import derelict.util.system;
 import derelict.opengl.gl,
        derelict.opengl.types : GLVersion, usingContexts;
 
-static if(!usingContexts) {
-    private alias ExtLoaderFunc = bool function(ref GLLoader loader, bool doThrow);
-    private struct ExtLoader
-    {
-        string name;
-        ExtLoaderFunc load;
-    }
+private alias ExtLoaderFunc = bool function(ref GLLoader loader, bool doThrow);
+private struct ExtLoader
+{
+    string name;
+    ExtLoaderFunc load;
 }
 
 struct GLLoader


### PR DESCRIPTION
I have to compile in single-file mode due to an obscure compiler crash on macOS. For some reason, the global symbols within the `static if` are not visible when the matching static if within `GLLoader` is compiled. Since they are `private` anyway, just removing the outer `static if` seems like a viable workaround.